### PR TITLE
fix: adjusting mobile view of user profile page

### DIFF
--- a/frontend/src/custom.scss
+++ b/frontend/src/custom.scss
@@ -55,7 +55,3 @@ body {
   display: -webkit-box;
   -webkit-box-orient: vertical;
 }
-
-.user-info {
-  min-width: 800px;
-}


### PR DESCRIPTION
# Description

There was an issue on the frontend of the profile page that was preventing mobile users from following other users' profiles.
Upon investigation, I found that a CSS declaration was giving an unnecessary min-width to the container with .user-info class, which was causing the follow button to be out of view on mobile devices.

To fix this, I removed the min-width declaration and tested the page on various devices to ensure that the follow button was now visible in the viewport.